### PR TITLE
Changing MobileDevice framework location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all:
 	@echo "Making deviceconsole..."
-	@$(CC) -O3 main.c -o deviceconsole -F/System/Library/PrivateFrameworks/ -framework MobileDevice -framework CoreFoundation
+	@$(CC) -O3 main.c -o deviceconsole -F/Library/Apple/System/Library/PrivateFrameworks/ -framework MobileDevice -framework CoreFoundation
 
 .PHONY: all

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deviceconsole",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "iOS system log tailer that doesn't suck",
   "main": "deviceconsole",
   "scripts": {


### PR DESCRIPTION
Changing location to point directly to framework(/Library/Apple/System/Library/PrivateFrameworks/) rather than the Symlink(/System/Library/PrivateFrameworks/) with points back. With new Mac OS there seems to restriction on using the symlink to PrivateFrameworks.